### PR TITLE
feat: 댓글 목록조회 api 작업

### DIFF
--- a/comment-service/build.gradle
+++ b/comment-service/build.gradle
@@ -1,3 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation project(':common:snowflake')
 }

--- a/comment-service/src/main/java/board/comment/controller/CommentController.java
+++ b/comment-service/src/main/java/board/comment/controller/CommentController.java
@@ -1,0 +1,31 @@
+package board.comment.controller;
+
+import board.comment.service.CommentService;
+import board.comment.service.request.CommentRequest;
+import board.comment.service.response.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/v1/comments/{commentId}")
+    public CommentResponse read(
+            @PathVariable Long commentId
+    ) {
+        return commentService.read(commentId);
+    }
+
+    @PostMapping("/v1/comments")
+    public CommentResponse create(@RequestBody CommentRequest.Create request) {
+        return commentService.create(request);
+    }
+
+    @DeleteMapping("/v1/comments/{commentId}")
+    public void delete(@PathVariable Long commentId){
+        commentService.delete(commentId);
+    }
+}

--- a/comment-service/src/main/java/board/comment/controller/CommentController.java
+++ b/comment-service/src/main/java/board/comment/controller/CommentController.java
@@ -2,9 +2,12 @@ package board.comment.controller;
 
 import board.comment.service.CommentService;
 import board.comment.service.request.CommentRequest;
+import board.comment.service.response.CommentPageResponse;
 import board.comment.service.response.CommentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +28,26 @@ public class CommentController {
     }
 
     @DeleteMapping("/v1/comments/{commentId}")
-    public void delete(@PathVariable Long commentId){
+    public void delete(@PathVariable Long commentId) {
         commentService.delete(commentId);
+    }
+
+    @GetMapping("/v1/comments")
+    public CommentPageResponse readAll(
+            @RequestParam("articleId") Long articleId,
+            @RequestParam("page") Long page,
+            @RequestParam("pageSize") Long pageSize
+    ) {
+        return commentService.readAll(articleId, page, pageSize);
+    }
+
+    @GetMapping("/v1/comments/infinite-scroll")
+    public List<CommentResponse> readAll(
+            @RequestParam("articleId") Long articleId,
+            @RequestParam(value = "lastParentCommentId", required = false) Long lastParentCommentId,
+            @RequestParam(value = "lastCommentId", required = false) Long lastCommentId,
+            @RequestParam("pageSize") Long pageSize
+    ) {
+        return commentService.readAll(articleId, lastParentCommentId, lastCommentId, pageSize);
     }
 }

--- a/comment-service/src/main/java/board/comment/entity/Comment.java
+++ b/comment-service/src/main/java/board/comment/entity/Comment.java
@@ -1,0 +1,48 @@
+package board.comment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    @Id
+    private Long commentId;
+    private String content;
+    private Long parentCommentId;
+    private Long articleId;
+    private Long writerId;
+    private Boolean deleted;
+    private LocalDateTime createdAt;
+
+    public static Comment create(Long commentId, String content, Long parentCommentId, Long articleId, Long writerId) {
+        Comment comment = new Comment();
+        comment.commentId = commentId;
+        comment.content = content;
+        comment.parentCommentId = parentCommentId == null ? commentId : parentCommentId;
+        comment.articleId = articleId;
+        comment.writerId = writerId;
+        comment.deleted = false;
+        comment.createdAt = LocalDateTime.now();
+        return comment;
+    }
+
+    // root 댓글 확인
+    public boolean isRoot() {
+        return parentCommentId.longValue() == commentId;
+    }
+
+    public void delete() {
+        deleted = true;
+    }
+}
+

--- a/comment-service/src/main/java/board/comment/repository/CommentJpaRepository.java
+++ b/comment-service/src/main/java/board/comment/repository/CommentJpaRepository.java
@@ -1,0 +1,22 @@
+package board.comment.repository;
+
+import board.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentJpaRepository extends JpaRepository<Comment,Long> {
+    // 특정 게시글에서 특정 상위 댓글을 Parent Comment ID가 :parentCommentId이거인 댓글 개수를 가져올수 있음
+    @Query(
+            value = "select count(*) from (" +
+                    "   select comment_id from comment " +
+                    "   where article_id = :articleId and parent_comment_id = :parentCommentId " +
+                    ") t",
+            nativeQuery = true
+    )
+    Long countBy(
+            @Param("articleId") Long articleId,
+            @Param("parentCommentId") Long parentCommentId,
+            @Param("limit")Long limit
+    );
+}

--- a/comment-service/src/main/java/board/comment/repository/CommentJpaRepository.java
+++ b/comment-service/src/main/java/board/comment/repository/CommentJpaRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface CommentJpaRepository extends JpaRepository<Comment,Long> {
     // 특정 게시글에서 특정 상위 댓글을 Parent Comment ID가 :parentCommentId이거인 댓글 개수를 가져올수 있음
     @Query(
@@ -18,5 +20,63 @@ public interface CommentJpaRepository extends JpaRepository<Comment,Long> {
             @Param("articleId") Long articleId,
             @Param("parentCommentId") Long parentCommentId,
             @Param("limit")Long limit
+    );
+
+    @Query(
+            value = "select * " +
+                    "from (" +
+                    "   select comment_id as t_comment_id from comment " +
+                    "   where article_id = :articleId " +
+                    "   order by parent_comment_id asc, comment_id asc " +
+                    "   limit :limit offset :offset " +
+                    ") t left join comment on t.t_comment_id = comment.comment_id",
+            nativeQuery = true
+    )
+    List<Comment> findAll(
+            @Param("articleId") Long articleId,
+            @Param("offset") Long offset,
+            @Param("limit") Long limit
+    );
+
+    @Query(
+            value = "select count(*) from (" +
+                    "   select comment_id from comment " +
+                    "   where article_id = :articleId" +
+                    "   limit :limit" +
+                    ") t",
+            nativeQuery = true
+    )
+    Long count(
+            @Param("articleId") Long articleId,
+            @Param("limit") Long limit
+    );
+
+    @Query(
+            value = "select * " +
+                    "from comment " +
+                    "where article_id = :articleId " +
+                    "order by parent_comment_id asc, comment_id asc " +
+                    "limit :limit",
+            nativeQuery = true
+    )
+    List<Comment> findAllInfiniteScroll(
+            @Param("articleId") Long articleId,
+            @Param("limit") Long limit
+    );
+
+    @Query(
+            value = "select * " +
+                    "from comment " +
+                    "where article_id = :articleId " +
+                    "and (parent_comment_id, comment_id) > (:lastParentCommentId, :lastCommentId) " +
+                    "order by parent_comment_id asc, comment_id asc " +
+                    "limit :limit",
+            nativeQuery = true
+    )
+    List<Comment> findAllInfiniteScroll(
+            @Param("articleId") Long articleId,
+            @Param("lastParentCommentId") Long lastParentCommentId,
+            @Param("lastCommentId") Long lastCommentId,
+            @Param("limit") Long limit
     );
 }

--- a/comment-service/src/main/java/board/comment/service/CommentService.java
+++ b/comment-service/src/main/java/board/comment/service/CommentService.java
@@ -1,0 +1,81 @@
+package board.comment.service;
+
+import board.Snowflake;
+import board.comment.entity.Comment;
+import board.comment.repository.CommentJpaRepository;
+import board.comment.service.request.CommentRequest;
+import board.comment.service.response.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static java.util.function.Predicate.not;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final Snowflake snowflake = new Snowflake();
+    private final CommentJpaRepository commentJpaRepository;
+
+    @Transactional
+    public CommentResponse create(CommentRequest.Create request) {
+        Comment parent = findParent(request);
+
+        Comment comment = Comment.create(
+                snowflake.nextId(),
+                request.getContent(),
+                parent == null ? null : parent.getParentCommentId(),
+                request.getArticleId(),
+                request.getWriterId()
+        );
+        commentJpaRepository.save(comment);
+
+        return CommentResponse.from(comment);
+    }
+
+    private Comment findParent(CommentRequest.Create request) {
+        Long parentCommentId = request.getParentCommentId();
+        if (parentCommentId == null) {
+            return null;
+        }
+        return commentJpaRepository.findById(parentCommentId)
+                .filter(not(Comment::getDeleted))
+                .filter(Comment::isRoot)
+                .orElseThrow();
+    }
+
+    public CommentResponse read(Long commentId) {
+        Comment comment = commentJpaRepository.findById(commentId).orElseThrow();
+
+        return CommentResponse.from(comment);
+    }
+
+    @Transactional
+    public void delete(Long commentId) {
+        commentJpaRepository.findById(commentId)
+                .filter(not(Comment::getDeleted))
+                .ifPresent(comment -> {
+                    if (hasChildren(comment)) {
+                        comment.delete();
+                    } else {
+                        delete(comment);
+                    }
+                });
+    }
+
+    private boolean hasChildren(Comment comment) {
+        return commentJpaRepository.countBy(comment.getArticleId(), comment.getCommentId(), 2L) == 2;
+    }
+
+    private void delete(Comment comment) {
+        commentJpaRepository.delete(comment);
+        // 재귀적 삭제
+        if (!comment.isRoot()){
+            commentJpaRepository.findById(comment.getParentCommentId())
+                    .filter(Comment::getDeleted)
+                    .filter(not(this::hasChildren))
+                    .ifPresent(this::delete);
+        }
+    }
+}

--- a/comment-service/src/main/java/board/comment/service/PageLimitCalculator.java
+++ b/comment-service/src/main/java/board/comment/service/PageLimitCalculator.java
@@ -1,0 +1,16 @@
+package board.comment.service;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ *  페이지 번호 활성화에 필요한 카운트 계산
+ * util성이라 private 생성자와 final로 지정
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PageLimitCalculator {
+
+    public static Long calculatorPageLimit(Long page, Long pageSize, Long movablePageCount) {
+        return (((page-1) / movablePageCount) + 1) * pageSize * movablePageCount + 1;
+    }
+}

--- a/comment-service/src/main/java/board/comment/service/request/CommentRequest.java
+++ b/comment-service/src/main/java/board/comment/service/request/CommentRequest.java
@@ -1,0 +1,14 @@
+package board.comment.service.request;
+
+import lombok.Getter;
+
+public class CommentRequest {
+
+    @Getter
+    public static class Create{
+        private Long articleId;
+        private String content;
+        private Long parentCommentId;
+        private Long writerId;
+    }
+}

--- a/comment-service/src/main/java/board/comment/service/response/CommentPageResponse.java
+++ b/comment-service/src/main/java/board/comment/service/response/CommentPageResponse.java
@@ -1,0 +1,18 @@
+package board.comment.service.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CommentPageResponse {
+    private List<CommentResponse> comments;
+    private Long commentCount;
+
+    public static CommentPageResponse of(List<CommentResponse> comments,Long commentCount){
+        CommentPageResponse response = new CommentPageResponse();
+        response.comments = comments;
+        response.commentCount = commentCount;
+        return response;
+    }
+}

--- a/comment-service/src/main/java/board/comment/service/response/CommentResponse.java
+++ b/comment-service/src/main/java/board/comment/service/response/CommentResponse.java
@@ -1,0 +1,30 @@
+package board.comment.service.response;
+
+import board.comment.entity.Comment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentResponse {
+
+    private Long commentId;
+    private String content;
+    private Long parentCommentId;
+    private Long articleId;
+    private Long writerId;
+    private Boolean deleted;
+    private LocalDateTime createdAt;
+
+    public static CommentResponse from(Comment comment) {
+        CommentResponse response = new CommentResponse();
+        response.commentId = comment.getCommentId();
+        response.content = comment.getContent();
+        response.parentCommentId = comment.getParentCommentId();
+        response.articleId = comment.getArticleId();
+        response.writerId = comment.getWriterId();
+        response.deleted = comment.getDeleted();
+        response.createdAt = comment.getCreatedAt();
+        return response;
+    }
+}

--- a/comment-service/src/main/resources/application.yml
+++ b/comment-service/src/main/resources/application.yml
@@ -1,2 +1,16 @@
 server:
   port: 9001
+spring:
+  application:
+    name: board-comment-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/comment
+    username: root
+    password: root
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+    show-sql: false
+    hibernate:
+      ddl-auto: none

--- a/comment-service/src/test/java/data/DataInitializer.java
+++ b/comment-service/src/test/java/data/DataInitializer.java
@@ -1,0 +1,64 @@
+package data;
+
+import board.Snowflake;
+import board.comment.CommentApplication;
+import board.comment.entity.Comment;
+import board.comment.repository.CommentJpaRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SpringBootTest(classes = CommentApplication.class)
+public class DataInitializer {
+    @PersistenceContext
+    EntityManager entityManager;
+    @Autowired
+    TransactionTemplate transactionTemplate;
+    Snowflake snowflake = new Snowflake();
+    CountDownLatch latch = new CountDownLatch(EXECUTE_COUNT);
+
+    static final int BULK_INSERT_SIZE = 2000;
+    static final int EXECUTE_COUNT = 6000;
+    @Autowired
+    private CommentJpaRepository commentJpaRepository;
+
+
+    @Test
+    void initialize() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        for (int i = 0; i < EXECUTE_COUNT; i++) {
+            executorService.submit(() -> {
+                insert();
+                latch.countDown();
+                System.out.println("latch.getCount() = " + latch.getCount());
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+    }
+
+    void insert() {
+        transactionTemplate.executeWithoutResult(status -> {
+            Comment prev = null;
+            for (int i = 0; i < BULK_INSERT_SIZE; i++) {
+                Comment comment = Comment.create(
+                        snowflake.nextId(),
+                        "content",
+                        i % 2 == 0 ? null : prev.getParentCommentId(),
+                        1L,
+                        1L
+                );
+                prev = comment;
+                entityManager.persist(comment);
+            }
+        });
+    }
+}
+


### PR DESCRIPTION
- 상위 댓글은 항상 하위 댓글보다 먼저 생성되고 하위 댓글은 상위 댓글 별 순서대로 생성된다.
- (부모 댓글 id, 댓글 id)의 오름차순 정렬구조