### PR TITLE
feat: 게시글 조회수 증가,조회 api,  조회수 어뷰징 방지 정책 구현

### DIFF
--- a/view-service/build.gradle
+++ b/view-service/build.gradle
@@ -1,3 +1,7 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation project(':common:snowflake')
 }

--- a/view-service/src/main/java/board/view/controller/ArticleViewController.java
+++ b/view-service/src/main/java/board/view/controller/ArticleViewController.java
@@ -1,0 +1,29 @@
+package board.view.controller;
+
+import board.view.service.ArticleViewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ArticleViewController {
+
+    private final ArticleViewService articleViewService;
+
+    @PostMapping("/v1/article-views/articles/{articleId}/users/{userId}")
+    public Long increase(
+            @PathVariable("articleId") Long articleId,
+            @PathVariable("userId") Long userId
+    ) {
+        return articleViewService.increase(articleId, userId);
+    }
+
+    @GetMapping("/v1/article-views/articles/{articleId}/count")
+    public Long count(@PathVariable("articleId") Long articleId) {
+        return articleViewService.count(articleId);
+    }
+}

--- a/view-service/src/main/java/board/view/entity/ArticleViewCount.java
+++ b/view-service/src/main/java/board/view/entity/ArticleViewCount.java
@@ -1,0 +1,24 @@
+package board.view.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleViewCount {
+
+    @Id
+    private Long articleId;
+    private Long viewCount;
+
+    public static ArticleViewCount init(Long articleId, Long viewCount) {
+        ArticleViewCount articleViewCount = new ArticleViewCount();
+        articleViewCount.articleId = articleId;
+        articleViewCount.viewCount = viewCount;
+        return articleViewCount;
+    }
+}

--- a/view-service/src/main/java/board/view/repository/ArticleViewCountBackUpJpaRepository.java
+++ b/view-service/src/main/java/board/view/repository/ArticleViewCountBackUpJpaRepository.java
@@ -1,0 +1,21 @@
+package board.view.repository;
+
+import board.view.entity.ArticleViewCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ArticleViewCountBackUpJpaRepository extends JpaRepository<ArticleViewCount,Long> {
+
+    @Query(
+            value = "update article_view_count set view_count = :viewCount " +
+                    "where article_id = :articleId and view_count < :viewCount",
+            nativeQuery = true
+    )
+    @Modifying
+    int updateViewCount(
+        @Param("articleId") Long articleId,
+        @Param("viewCount") Long viewCount
+    );
+}

--- a/view-service/src/main/java/board/view/repository/ArticleViewCountRedisRepository.java
+++ b/view-service/src/main/java/board/view/repository/ArticleViewCountRedisRepository.java
@@ -1,0 +1,27 @@
+package board.view.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleViewCountRedisRepository {
+    private final StringRedisTemplate redisTemplate;
+
+    // view::article::{article_id}::view_count
+    private static final String KEY_FORMAT = "view:article:%s:view_count";
+
+    public Long read(Long articleId) {
+        String result = redisTemplate.opsForValue().get(generateKey(articleId));
+        return result == null ? 0L : Long.valueOf(result);
+    }
+
+    public Long increase(Long articleId) {
+        return redisTemplate.opsForValue().increment(generateKey(articleId));
+    }
+
+    private String generateKey(Long articleId) {
+        return KEY_FORMAT.formatted(articleId);
+    }
+}

--- a/view-service/src/main/java/board/view/repository/ArticleViewDistributedLockRepository.java
+++ b/view-service/src/main/java/board/view/repository/ArticleViewDistributedLockRepository.java
@@ -1,0 +1,27 @@
+package board.view.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+// 게시글 조회에 대한 분산 락 관리
+@Repository
+@RequiredArgsConstructor
+public class ArticleViewDistributedLockRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    // view::article::{article_id}::user::{userId}::lock
+    private static final String KEY_FORMAT = "view:article:%s:user:%s:lock";
+
+    public boolean lock(Long articleId, Long userId, Duration ttl) {
+        String key = generateKey(articleId, userId);
+        return redisTemplate.opsForValue().setIfAbsent(key,"",ttl);
+    }
+
+    private String generateKey(Long articleId, Long userId) {
+        return KEY_FORMAT.formatted(articleId, userId);
+    }
+}

--- a/view-service/src/main/java/board/view/service/ArticleViewCountBackUpProcessor.java
+++ b/view-service/src/main/java/board/view/service/ArticleViewCountBackUpProcessor.java
@@ -1,0 +1,26 @@
+package board.view.service;
+
+import board.view.entity.ArticleViewCount;
+import board.view.repository.ArticleViewCountBackUpJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleViewCountBackUpProcessor {
+
+    private final ArticleViewCountBackUpJpaRepository articleViewCountBackUpJpaRepository;
+
+    @Transactional
+    public void backUp(Long articleId, Long viewCount) {
+        int result = articleViewCountBackUpJpaRepository.updateViewCount(articleId, viewCount);
+        if (result == 0) {
+            articleViewCountBackUpJpaRepository.findById(articleId)
+                    .ifPresentOrElse(ignored -> {},
+                        ()->articleViewCountBackUpJpaRepository.save(
+                                ArticleViewCount.init(articleId, viewCount))
+                    );
+        }
+    }
+}

--- a/view-service/src/main/java/board/view/service/ArticleViewService.java
+++ b/view-service/src/main/java/board/view/service/ArticleViewService.java
@@ -1,8 +1,12 @@
 package board.view.service;
 
 import board.view.repository.ArticleViewCountRedisRepository;
+import board.view.repository.ArticleViewDistributedLockRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.IllegalFormatCodePointException;
 
 @Service
 @RequiredArgsConstructor
@@ -10,14 +14,20 @@ public class ArticleViewService {
 
     private final ArticleViewCountRedisRepository articleViewCountRedisRepository;
     private final ArticleViewCountBackUpProcessor articleViewCountBackUpProcessor;
+    private final ArticleViewDistributedLockRepository articleViewDistributedLockRepository;
 
     private static final int BACK_UP_BACK_SIZE = 100;
+    private static final Duration ABUSING_TTL = Duration.ofMinutes(10);
 
     public Long increase(Long articleId, Long userId) {
+        if (!articleViewDistributedLockRepository.lock(articleId,userId,ABUSING_TTL)){
+            return articleViewCountRedisRepository.read(articleId);
+        }
+
         Long count = articleViewCountRedisRepository.increase(articleId);
 
         if (count % BACK_UP_BACK_SIZE == 0) {
-            articleViewCountBackUpProcessor.backUp(articleId,count);
+            articleViewCountBackUpProcessor.backUp(articleId, count);
         }
         return count;
     }

--- a/view-service/src/main/java/board/view/service/ArticleViewService.java
+++ b/view-service/src/main/java/board/view/service/ArticleViewService.java
@@ -1,0 +1,28 @@
+package board.view.service;
+
+import board.view.repository.ArticleViewCountRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleViewService {
+
+    private final ArticleViewCountRedisRepository articleViewCountRedisRepository;
+    private final ArticleViewCountBackUpProcessor articleViewCountBackUpProcessor;
+
+    private static final int BACK_UP_BACK_SIZE = 100;
+
+    public Long increase(Long articleId, Long userId) {
+        Long count = articleViewCountRedisRepository.increase(articleId);
+
+        if (count % BACK_UP_BACK_SIZE == 0) {
+            articleViewCountBackUpProcessor.backUp(articleId,count);
+        }
+        return count;
+    }
+
+    public Long count(Long articleId) {
+        return articleViewCountRedisRepository.read(articleId);
+    }
+}

--- a/view-service/src/main/resources/application.yml
+++ b/view-service/src/main/resources/application.yml
@@ -1,2 +1,20 @@
 server:
   port: 9003
+spring:
+  application:
+    name: board-view-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/article_view
+    username: root
+    password: root
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: none
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379

--- a/view-service/src/test/java/board/view/repository/ArticleViewCountBackUpJpaRepositoryTest.java
+++ b/view-service/src/test/java/board/view/repository/ArticleViewCountBackUpJpaRepositoryTest.java
@@ -1,0 +1,46 @@
+package board.view.repository;
+
+import board.view.entity.ArticleViewCount;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ArticleViewCountBackUpJpaRepositoryTest {
+
+    @Autowired
+    private ArticleViewCountBackUpJpaRepository articleViewCountBackUpJpaRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("")
+    void test(){
+        //given
+        articleViewCountBackUpJpaRepository.save(
+                ArticleViewCount.init(1L, 0L)
+        );
+        entityManager.flush();
+        entityManager.clear();
+        //when
+        int result1 = articleViewCountBackUpJpaRepository.updateViewCount(1L, 100L);
+        int result2 = articleViewCountBackUpJpaRepository.updateViewCount(1L,300L);
+        int result3 = articleViewCountBackUpJpaRepository.updateViewCount(1L,200L);
+        //then
+        assertThat(result1).isEqualTo(1);
+        assertThat(result2).isEqualTo(1);
+        assertThat(result3).isEqualTo(0);
+
+        ArticleViewCount articleViewCount = articleViewCountBackUpJpaRepository.findById(1L).get();
+        assertThat(articleViewCount.getViewCount()).isEqualTo(300L);
+    }
+}


### PR DESCRIPTION
feat: 게시글 조회수 증가,조회 api
- 조회수 redis 저장
- ArticleViewCount 백업 엔티티 생성
- BackUpSize 100으로 count 100 될 시 db로 저장.

feat: 조회수 어뷰징 방지 정책 구현
- 각 사용자는 게시글 1개당 10분에 1번 조회수 증가
- 10분에 2회 이상 조회할 시 어뷰징으로 판단하여 집계 x
- 게시글 조회수는 트래픽이 많을것을 예상하여 ttl도 지원하는 Redis를 사용하여 구현.